### PR TITLE
Change DisableAutoTLSLabelKey to DisableAutoTLSAnnotationKey

### DIFF
--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -35,6 +35,10 @@ const (
 	// Istio-based Ingress will reconcile into a VirtualService).
 	IngressClassAnnotationKey = "networking.knative.dev/ingress.class"
 
+	// DisableAutoTLSAnnotationKey is the label key attached to a namespace to indicate that
+	// AutoTLS should not be enabled for it.
+	DisableAutoTLSAnnotationKey = "networking.knative.dev/disableAutoTLS"
+	
 	// IngressLabelKey is the label key attached to underlying network programming
 	// resources to indicate which Ingress triggered their creation.
 	IngressLabelKey = GroupName + "/ingress"
@@ -80,10 +84,6 @@ const (
 	// DisableWildcardCertLabelKey is the label key attached to a namespace to indicate that
 	// a wildcard certificate should be not created for it.
 	DisableWildcardCertLabelKey = "networking.knative.dev/disableWildcardCert"
-
-	// DisableAutoTLSLabelKey is the label key attached to a namespace to indicate that
-	// AutoTLS should not be enabled for it.
-	DisableAutoTLSLabelKey = "networking.knative.dev/disableAutoTLS"
 
 	// WildcardCertDomainLabelKey is the label key attached to a certificate to indicate the
 	// domain for which it was issued.


### PR DESCRIPTION
Fix the name since we're setting this via an annotation, not a label.